### PR TITLE
Add error case test for useGoalsQuery

### DIFF
--- a/src/hooks/useGoalsQuery.test.tsx
+++ b/src/hooks/useGoalsQuery.test.tsx
@@ -3,6 +3,11 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useGoalsQuery } from './useGoalsQuery';
 import React from 'react';
+import { toast } from '@/hooks/use-toast';
+
+jest.mock('@/hooks/use-toast', () => ({
+  toast: jest.fn(),
+}));
 
 const createWrapper = () => {
   const queryClient = new QueryClient({
@@ -44,5 +49,24 @@ describe('useGoalsQuery', () => {
       expect(goal).toHaveProperty('status');
       expect(goal).toHaveProperty('progress');
     });
+  });
+
+  it('should handle query errors and show a toast', async () => {
+    const failingQuery = jest.fn(async () => {
+      throw new Error('fail');
+    });
+
+    const { result } = renderHook(() => useGoalsQuery({ queryFn: failingQuery }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(toast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: 'Failed to fetch goals data',
+        variant: 'destructive',
+      })
+    );
   });
 });


### PR DESCRIPTION
## Summary
- extend `useGoalsQuery.test.tsx` with a failure scenario
- mock `toast` to confirm errors surface to the user

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*