### PR TITLE
Fix applySort equality comparison

### DIFF
--- a/src/utils/employeeFilters.test.ts
+++ b/src/utils/employeeFilters.test.ts
@@ -1,0 +1,33 @@
+import { applySort } from './employeeFilters';
+import { UserRole } from '@/lib/permissions';
+import type { Employee } from '@/types/employee';
+
+describe('applySort', () => {
+  it('returns 0 when values are equal and maintains original order', () => {
+    const emp1: Employee & { score: number } = {
+      id: '1',
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'john@example.com',
+      role: UserRole.EMPLOYEE,
+      departmentId: 'd1',
+      departmentName: 'Dept',
+      divisionId: 'div',
+      divisionName: 'Div',
+      status: 'Active',
+      createdAt: '2024-01-01',
+      updatedAt: '2024-01-01',
+      score: 10,
+    };
+
+    const emp2: Employee & { score: number } = {
+      ...emp1,
+      id: '2',
+      email: 'jane@example.com',
+    };
+
+    const sorted = applySort([emp1, emp2], 'score' as any, 'asc');
+    expect(sorted[0]).toBe(emp1);
+    expect(sorted[1]).toBe(emp2);
+  });
+});

--- a/src/utils/employeeFilters.ts
+++ b/src/utils/employeeFilters.ts
@@ -66,24 +66,38 @@ export function applyFilters(employees: Employee[], filters: EmployeeFilters): E
   return filtered;
 }
 
-export function applySort(employees: Employee[], sortColumn: SortColumn, sortDirection: SortDirection): Employee[] {
+// Sort a list of employees by the given column and direction.
+// Undefined values are pushed to the bottom (or top when sorting descending).
+// The comparator explicitly returns 0 when both values are equal so that the
+// relative order of equal records is preserved.
+export function applySort(
+  employees: Employee[],
+  sortColumn: SortColumn,
+  sortDirection: SortDirection
+): Employee[] {
   return [...employees].sort((a: any, b: any) => {
     const valueA = a[sortColumn];
     const valueB = b[sortColumn];
-    
+
     if (!valueA && !valueB) return 0;
     if (!valueA) return sortDirection === 'asc' ? 1 : -1;
     if (!valueB) return sortDirection === 'asc' ? -1 : 1;
-    
+
     if (typeof valueA === 'string' && typeof valueB === 'string') {
-      return sortDirection === 'asc' 
-        ? valueA.localeCompare(valueB) 
+      return sortDirection === 'asc'
+        ? valueA.localeCompare(valueB)
         : valueB.localeCompare(valueA);
     }
-    
-    return sortDirection === 'asc' 
-      ? (valueA > valueB ? 1 : -1)
-      : (valueA < valueB ? 1 : -1);
+
+    if (valueA === valueB) return 0;
+
+    return sortDirection === 'asc'
+      ? valueA > valueB
+        ? 1
+        : -1
+      : valueA > valueB
+        ? -1
+        : 1;
   });
 }
 


### PR DESCRIPTION
## Summary
- refine applySort docs and logic to return `0` for equal values
- add unit test for applySort equality behaviour

## Testing
- `bun test src/utils/employeeFilters.test.ts`
- `bun test` *(fails: Cannot find module 'react/jsx-dev-runtime' for hooks test)*