### PR TITLE
Add AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# Contributor Guidelines
+
+## Setup
+
+After cloning, run:
+
+```sh
+./setup.sh
+```
+
+This installs all project dependencies. The environment loses network access after setup, so installing packages manually will fail.
+
+## Common Tasks
+
+- **Lint**: `npm run lint`
+- **Build**: `npm run build`
+- **Tests**: run `npm test` (or `npm run test`) if a test script is defined in `package.json`.
+
+## Commit Messages
+
+Use clear, descriptive commit messages that explain the purpose of your changes.


### PR DESCRIPTION
## Summary
- add contributor instructions in `AGENTS.md`

## Testing
- `sh setup.sh` *(fails: EHOSTUNREACH)*
- `npm run lint` *(fails: module not found)*
- `npm run build` *(fails: vite not found)*
- `npm test` *(fails: missing script)*