### PR TITLE
Move tooltip imports up

### DIFF
--- a/src/components/ui/sidebar/context.tsx
+++ b/src/components/ui/sidebar/context.tsx
@@ -1,4 +1,6 @@
 import * as React from "react"
+import { cn } from "@/lib/utils"
+import { TooltipProvider } from "@/components/ui/tooltip"
 import { useIsMobile } from "@/hooks/use-mobile"
 
 // Constants moved from the original file
@@ -138,7 +140,3 @@ export const SidebarProvider = React.forwardRef<
   }
 )
 SidebarProvider.displayName = "SidebarProvider"
-
-// Import this here to avoid circular dependencies
-import { cn } from "@/lib/utils"
-import { TooltipProvider } from "@/components/ui/tooltip"


### PR DESCRIPTION
## Summary
- move `cn` and `TooltipProvider` imports to top of `context.tsx`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*