### PR TITLE
Add sidebar collapsed tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "bun test"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/src/components/ui/sidebar/__tests__/SidebarCollapsed.test.tsx
+++ b/src/components/ui/sidebar/__tests__/SidebarCollapsed.test.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import {
+  SidebarProvider,
+  Sidebar,
+  SidebarContent,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+} from '@/components/ui/sidebar';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+test('menu button uses collapsed classes', () => {
+  render(
+    <SidebarProvider defaultOpen={false}>
+      <Sidebar>
+        <SidebarContent>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton>
+                <svg data-testid="icon" />
+                <span>Dashboard</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarContent>
+      </Sidebar>
+    </SidebarProvider>
+  );
+
+  const button = screen.getByRole('button');
+  expect(button.className).toContain('justify-center');
+  expect(button.className).toContain('group-data-[state=collapsed]:flex');
+  expect(button.className).toContain('[&>span]:group-data-[state=collapsed]:hidden');
+});


### PR DESCRIPTION
## Summary
- add npm test script wired to Bun
- test sidebar in collapsed state for icon centering and text hiding

## Testing
- `npm test` *(fails: Cannot find module 'react/jsx-dev-runtime' ...)*