### PR TITLE
Implement offline setup using tarball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ node_modules
 dist
 dist-ssr
 *.local
+node_modules.tar.gz
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ git clone <YOUR_GIT_URL>
 cd <YOUR_PROJECT_NAME>
 
 # Step 3: Install the necessary dependencies.
+# If you have a prebuilt `node_modules.tar.gz` archive, copy it to the project
+# root before running the setup script. The script will extract the archive
+# instead of downloading packages from the internet, allowing offline setup.
 ./setup.sh
 
 # Step 4: Lint the code

--- a/setup.sh
+++ b/setup.sh
@@ -2,5 +2,16 @@
 set -e
 
 # Install dependencies using npm in CI-friendly way
-npm ci
+# If a prepacked node_modules tarball is present, use it instead of npm ci
+
+TARBALL="node_modules.tar.gz"
+
+if [ -f "$TARBALL" ]; then
+  echo "Using prebuilt dependencies from $TARBALL"
+  rm -rf node_modules
+  mkdir -p node_modules
+  tar -xzf "$TARBALL" -C node_modules --strip-components=1
+else
+  npm ci
+fi
 


### PR DESCRIPTION
## Summary
- allow setup.sh to extract dependencies from `node_modules.tar.gz` when present
- document offline setup in README
- ignore `node_modules.tar.gz` in git

## Testing
- `./setup.sh` *(fails: connect EHOSTUNREACH)*